### PR TITLE
fix: Fix hideNonClickableBadges configuration

### DIFF
--- a/frontend/amundsen_application/static/js/components/Badges/BadgeBrowseList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Badges/BadgeBrowseList/index.tsx
@@ -9,7 +9,10 @@ import {
   AVAILABLE_BADGES_TITLE,
   BROWSE_BADGES_TITLE,
 } from 'components/Badges/BadgeBrowseList/constants';
-import { isShowBadgesInHomeEnabled } from 'config/config-utils';
+import {
+  hideNonClickableBadges,
+  isShowBadgesInHomeEnabled,
+} from 'config/config-utils';
 
 export interface BadgeBrowseListProps {
   badges: Badge[];
@@ -26,7 +29,10 @@ const BadgeBrowseListShort: React.FC<BadgeBrowseListProps> = ({
         <h2 className="available-badges-header-title">
           {AVAILABLE_BADGES_TITLE}
         </h2>
-        <BadgeList badges={badges} />
+        <BadgeList
+          badges={badges}
+          hideNonClickableBadges={hideNonClickableBadges()}
+        />
       </article>
     );
   }

--- a/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.spec.tsx
+++ b/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.spec.tsx
@@ -42,6 +42,7 @@ const setup = (propOverrides?: Partial<BadgeListProps>) => {
   const props = {
     badges,
     onBadgeClick: () => {},
+    hideNonClickableBadges: false,
     ...propOverrides,
   };
   // eslint-disable-next-line react/jsx-props-no-spreading
@@ -110,6 +111,17 @@ describe('BadgeList', () => {
         const { wrapper } = setup({ badges: columnBadges });
         const expected = 2;
         const actual = wrapper.find('.static-badge').length;
+
+        expect(actual).toEqual(expected);
+      });
+
+      it('renders null when hideNonClickableBadges is true', () => {
+        const { wrapper } = setup({
+          badges: columnBadges,
+          hideNonClickableBadges: true,
+        });
+        const expected = 2;
+        const actual = wrapper.find('null').length;
 
         expect(actual).toEqual(expected);
       });

--- a/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.tsx
+++ b/frontend/amundsen_application/static/js/components/Badges/BadgeList/index.tsx
@@ -3,7 +3,7 @@
 
 import * as React from 'react';
 
-import { getBadgeConfig, hideNonClickableBadges } from 'config/config-utils';
+import { getBadgeConfig } from 'config/config-utils';
 import { BadgeStyle, BadgeStyleConfig } from 'config/config-types';
 
 import { convertText, CaseType } from 'utils/textUtils';
@@ -18,6 +18,7 @@ const COLUMN_BADGE_CATEGORY = 'column';
 export interface BadgeListProps {
   badges: Badge[];
   onBadgeClick: (badgeText: string) => void;
+  hideNonClickableBadges?: boolean;
 }
 
 export interface ActionableBadgeProps {
@@ -58,7 +59,7 @@ export default class BadgeList extends React.Component<BadgeListProps> {
   };
 
   render() {
-    const { badges } = this.props;
+    const { badges, hideNonClickableBadges } = this.props;
     const alphabetizedBadges = badges.sort((a, b) => {
       const aName = (a.badge_name ? a.badge_name : a.tag_name) || '';
       const bName = (b.badge_name ? b.badge_name : b.tag_name) || '';
@@ -85,7 +86,7 @@ export default class BadgeList extends React.Component<BadgeListProps> {
           if (
             badge.badge_name &&
             badge.category === COLUMN_BADGE_CATEGORY &&
-            !hideNonClickableBadges()
+            !hideNonClickableBadges
           ) {
             return (
               <StaticBadge


### PR DESCRIPTION
At the moment, when `hideNonClickableBadges` is configured to be `true`, the column badges are hidden everywhere in the app. This PR makes to changes to hide them only on the homepage.